### PR TITLE
Minor demographic change in China

### DIFF
--- a/Cold War Iron Curtain/history/states/621-China 18.txt
+++ b/Cold War Iron Curtain/history/states/621-China 18.txt
@@ -45,7 +45,7 @@ state = {
 		set_variable = { tourism_infrastructure = 0 }
 		
 		#1st is majority. Up to 3 minorities below. First is Majority, Next 3 are minorities, largest to smallest
-		add_to_array = { culture = 106 } 		
+		add_to_array = { culture = 105 } 		
 		add_to_array = { culture = 175 } 
 
 		##RELIGIONS##


### PR DESCRIPTION
Suiyuan now has Mandarin as a primary culture like it was historically (and still is today) instead of Tibetan.